### PR TITLE
React interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ npm start
 This will build the project and serve it on [http://localhost:5000](http://localhost:5000).
 
 ## Quirks
-Just like you need to have `import React from 'react'` in every JSX file in a React project, you need to include `import createElement from 'inferno-create-element'` in every JSX file here.
+The project has been designed with interop of React-like libraries in mind. We want to easily be able to switch and test different libraries by changing a build step. So it requires you put a standard `import React from 'react'` in every JSX file.
 
-This is because JSX elements are normally transpiled to `React.createElement(...)`, but here Bublé has been instructed to transpile them to just `createElement(...)`, so the createElement function needs to be available.
+This is because JSX elements, like in any React project, are transpiled to `React.createElement(...)` by Bublé, everything still works with Inferno because `react` and `react-dom` have been aliased in the Rollup build, to point to `inferno-create-element` and `inferno-dom`.
+
+If you would rather not pretend you're using React you can easily instruct Bublé to transpile JSX to just `createElement(...)`, and include `import createElement from 'inferno-create-element'` in every JSX file instead. There is a line to uncomment in the `rollup.config.js` file for that.
+
 
 ## App structure
 Well, there isn't much. `src/index.js` which loads and renders the `src/components/Hello.js` component.
@@ -19,4 +22,4 @@ Well, there isn't much. `src/index.js` which loads and renders the `src/componen
 ## Scripts
 * `npm run build` Builds the project to `dist`
 * `npm start` - Builds and serves the project
-* `npm run watch` - Builds and serves the project, then watches the `src` folder and rebuilds the project on changes.
+* `npm run watch` - Watches the `src` folder and rebuilds the project on changes.

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "",
   "main": "index.js",
   "watch": {
-    "build": "src/**"
+    "build": "src/**/*.*"
   },
   "scripts": {
     "build": "rollup -c",
     "start": "npm run build && node scripts/start.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "watch": "npm run start & npm-watch"
+    "watch": "npm-watch"
   },
   "repository": {
     "type": "git",
@@ -30,7 +30,9 @@
   "devDependencies": {
     "buble": "0.14.2",
     "express": "4.14.0",
+    "npm-watch": "0.1.6",
     "rollup": "0.36.3",
+    "rollup-plugin-alias": "1.2.0",
     "rollup-plugin-buble": "0.14.0",
     "rollup-plugin-commonjs": "5.0.5",
     "rollup-plugin-node-resolve": "2.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,14 +2,21 @@ import buble from 'rollup-plugin-buble';
 import uglify from 'rollup-plugin-uglify';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import alias from 'rollup-plugin-alias';
 
 export default {
   entry: 'src/index.js',
   external: [],
   moduleName: 'inferno-starter',
   plugins: [
+    alias({
+      'react-dom': __dirname + '/scripts/react-dom-to-inferno-dom.js',
+      react: __dirname + '/scripts/react-to-inferno'
+    }),
     buble({
-      jsx: 'createElement',
+      // uncomment this to use `import createElement from
+      // 'inferno-create-element';` with jsx
+      // jsx: 'createElement',
       objectAssign: 'Object.assign'
     }),
     uglify(),

--- a/scripts/react-dom-to-inferno-dom.js
+++ b/scripts/react-dom-to-inferno-dom.js
@@ -1,0 +1,2 @@
+import InfernoDOM from 'inferno-dom';
+export default InfernoDOM;

--- a/scripts/react-to-inferno.js
+++ b/scripts/react-to-inferno.js
@@ -1,0 +1,5 @@
+import createElement from 'inferno-create-element';
+
+export default {
+  createElement
+};

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -10,7 +10,7 @@ app.set('port', (process.env.PORT || 5000));
 
 app.use('/dist', express.static(DIST));
 app.use((req, res) => {
-  res.sendfile(path.join( HOME, 'index.html' ));
+  res.sendFile(path.join( HOME, 'index.html' ));
 });
 
 

--- a/src/components/Hello.js
+++ b/src/components/Hello.js
@@ -1,5 +1,5 @@
-import createElement from 'inferno-create-element';
+import React from 'react';
 
 export default ({ who }) => (
-  <div>Hello, {who}</div>
+  <div>Hello, {who}!</div>
 );

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-import InfernoDOM from 'inferno-dom';
-import createElement from 'inferno-create-element';
+import React from 'react';
+import ReactDOM from 'react-dom';
 
 import Hello from './components/Hello';
 
-InfernoDOM.render(
+ReactDOM.render(
   <Hello who="World" />,
   document.getElementById("app")
 );


### PR DESCRIPTION
To increase portability we want to use `import React from 'react'` with JSX.

This PR set's up aliases for `react` and `react-dom` to point to Inferno methods.